### PR TITLE
Support of posixGroup

### DIFF
--- a/src/main/java/org/esupportail/smsu/services/ldap/LdapUtils.java
+++ b/src/main/java/org/esupportail/smsu/services/ldap/LdapUtils.java
@@ -87,8 +87,8 @@ public class LdapUtils {
 	private String userDnPath;
 	private String userIdAttribute;
 	private String groupMemberAttribute;
-	private String groupNameAttribute;
-	
+	private String groupNameAttribute;	
+	private String groupMemberContainsUserAttribute;
 	
 	/**
 	 * The objectClass ldap attribute to add if the userTermsOfUseAttribute or userPagerAttribute need a specific ldap schema
@@ -475,8 +475,11 @@ public class LdapUtils {
 	 * @return the list of user group
 	 */
 	public List<UserGroup> getUserGroupsByUid(final String uid) {
-		String rdn = userIdAttribute + '=' + uid + "," + userDnPath;
-		String filter = groupMemberAttribute + "=" + rdn;
+		String rid = userIdAttribute + '=' + uid + "," + userDnPath;
+		if("uid".equalsIgnoreCase(groupMemberContainsUserAttribute)) {
+			rid = uid;
+		}
+		String filter = groupMemberAttribute + "=" + rid;
 		logger.debug("search ldap groups with ldap filter : " + filter);
 		return convertToUserGroups(ldapGroupService.getLdapGroupsFromFilter(filter));
 	}
@@ -668,6 +671,10 @@ public class LdapUtils {
 
 	public void setGroupNameAttribute(String groupNameAttribute) {
 		this.groupNameAttribute = groupNameAttribute;
+	}
+
+	public void setGroupMemberContainsUserAttribute(String groupMemberContainsUserAttribute) {
+		this.groupMemberContainsUserAttribute = groupMemberContainsUserAttribute;
 	}
 
 	public void setUserIdAttribute(String userIdAttribute) {

--- a/src/main/resources/properties/config.sample.properties
+++ b/src/main/resources/properties/config.sample.properties
@@ -83,6 +83,10 @@ ldap.objectClassToAdd=
 ldap.group.dnSubPath=ou=groups
 ldap.group.idAttribute=cn
 ldap.group.groupMemberAttr=member
+### ldap.group.groupMemberContainsUserAttribute :
+# set to dn if the groupMemberAttribute value is the full dn of user (like in groupOfNames), 
+# set to uid if the groupMemberAttribute value is simply the uid (like in posixGroup)
+ldap.group.groupMemberContainsUserAttribute=dn
 ldap.group.groupSearchAttr=description
 ldap.group.groupSearchDisplayedAttr=description
 ldap.group.nameAttr=description

--- a/src/main/resources/properties/ldap/ldap.xml
+++ b/src/main/resources/properties/ldap/ldap.xml
@@ -231,6 +231,7 @@
 		<property name="groupMemberAttribute" value="${ldap.group.groupMemberAttr}"/>
 		<property name="groupNameAttribute" value="${ldap.group.nameAttr}"/>
 		<property name="objectClassToAdd" value="${ldap.objectClassToAdd}"/>
+		<property name="groupMemberContainsUserAttribute" value="${ldap.group.groupMemberContainsUserAttribute}"/>
 	</bean>
 
 </beans>


### PR DESCRIPTION
 set to true if the groupMemberAttribute is the full dn of user (like in groupOfNames),
 set to false if the groupMemberAttribute is simply the uid (like posixGroup)

Without this, at the moment esup-smsu can support only groups like groupOfNames (ant not posixGroup).