### PR TITLE
Logs : log full trace of SMSU CreateMessageException

### DIFF
--- a/src/main/java/org/esupportail/smsu/exceptions/CreateMessageException.java
+++ b/src/main/java/org/esupportail/smsu/exceptions/CreateMessageException.java
@@ -6,6 +6,14 @@ public abstract class CreateMessageException extends Exception {
 
 	private static final long serialVersionUID = 6792087453400066168L;
 	
+	public CreateMessageException() {
+		super();
+	}
+	
+	public CreateMessageException(String errorMsg, Exception e) {
+		super(errorMsg, e);
+	}
+
 	abstract public String toI18nString(I18nService i18nService);
 
 	static public class Wrapper extends CreateMessageException {
@@ -16,6 +24,7 @@ public abstract class CreateMessageException extends Exception {
 		public Exception previousException;
 
 		public Wrapper(String errorMsg, Exception e) {
+			super(errorMsg, e);
 			this.errorMsg = errorMsg;
 			this.previousException = e;
 		}

--- a/src/main/java/org/esupportail/smsu/web/controllers/exceptionmappers/CreateMessageExceptionMapper.java
+++ b/src/main/java/org/esupportail/smsu/web/controllers/exceptionmappers/CreateMessageExceptionMapper.java
@@ -1,5 +1,6 @@
 package org.esupportail.smsu.web.controllers.exceptionmappers;
 
+import org.apache.log4j.Logger;
 import org.esupportail.smsu.exceptions.CreateMessageException;
 import org.esupportail.smsu.web.Helper;
 import org.springframework.http.HttpStatus;
@@ -9,8 +10,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class CreateMessageExceptionMapper {
+	
+    private final Logger logger = Logger.getLogger(getClass());
+    
     @ExceptionHandler(CreateMessageException.class)
-    public ResponseEntity<?> toResponse(Exception ex) {
+    public ResponseEntity<?> toResponse(CreateMessageException ex) {
+    	logger.error("Handle Exception in CreateMessageExceptionMapper : " + ex.getMessage(), ex);
         return Helper.jsonErrorResponse(HttpStatus.BAD_REQUEST, ex.toString());
     }
 }


### PR DESCRIPTION
Actuellement, si smsu-api n'est pas joignable, lors de l'envoi d'un sms on retrouve dans les logs une erreur/exception sur le parsing de l'exception initiale ; exception initiale qui n'est par ailleurs pas affichée et loguée.

 L'exception logguée est seulement : 
<code>
2019-11-27 11:04:51,931 WARN  org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver - ExceptionHandlerExceptionResolver.java:392  - Failed to invoke @Exc\
eptionHandler method: public org.springframework.http.ResponseEntity<?> org.esupportail.smsu.web.controllers.exceptionmappers.CreateMessageExceptionMapper.toResponse(org.esupportail.smsu.\
exceptions.CreateMessageException)
org.codehaus.jackson.JsonParseException: Illegal character '.' (code 0x2e) in base64 content
 at [Source: N/A; line: -1, column: -1]
        at org.codehaus.jackson.node.TextNode._reportInvalidBase64(TextNode.java:291)
        at org.codehaus.jackson.node.TextNode._reportInvalidBase64(TextNode.java:267)
</code>

Avec la modification proposée, on retrouve en plus, et en erreur, l'exception d'origine/initiale avec l'ensemble de la trace.