### PR TITLE
Fix unique constraint on RCP_PHONE

### DIFF
--- a/src/main/resources/database/migrate_3.2.sql
+++ b/src/main/resources/database/migrate_3.2.sql
@@ -1,4 +1,5 @@
 -- remove unique on RCP_PHONE
 alter table recipient modify RCP_PHONE varchar(255) not null;
+drop index RCP_PHONE on recipient;
 -- add new index on both phone&login
 create index RCP_PHONE_LOGIN on recipient (RCP_PHONE, RCP_LOGIN);


### PR DESCRIPTION
Without this, we can have (if 2 recipients have the same phone number)
2020-04-10 11:35:09,275 ERROR org.hibernate.engine.jdbc.spi.SqlExceptionHelper - SqlExceptionHelper.java:144  - Duplicate entry 'xxxxxxxx' for key 'RCP_PHONE'
2020-04-10 11:35:09,275 ERROR org.hibernate.AssertionFailure - AssertionFailure.java:43   - HHH000099: an assertion failure occured (this may indicate a bug in Hibernate, but is more likely due to unsafe use of the session): org.hibernate.AssertionFailure: null id in org.esupportail.smsu.dao.beans.Recipient entry (don't flush the Session after an exception occurs)
